### PR TITLE
changed beta urls to 1.0 urls for Mozilla Backpack

### DIFF
--- a/badgewidget.php
+++ b/badgewidget.php
@@ -14,7 +14,7 @@ function loadBadges() {
 <?php
 $user = $_POST["user"];
 list($group,$name) = explode(".",$_POST["group"]);
-echo 'var url = "http://beta.openbadges.org/displayer/' . $user . '/group/' . $group . '.json";';
+echo 'var url = "https://backpack.openbadges.org/displayer/' . $user . '/group/' . $group . '.json";';
 echo 'var widgetcode = "<table>"';
 ?>
     
@@ -52,7 +52,7 @@ echo 'var widgetcode = "<table>"';
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>    
 <script type="text/javascript">
 
-<?php echo 'var url = "http://beta.openbadges.org/displayer/' . $user . '/group/' . $group . '.json";'; ?>
+<?php echo 'var url = "https://backpack.openbadges.org/displayer/' . $user . '/group/' . $group . '.json";'; ?>
 
     $.getJSON(url,
         function(data) {

--- a/findgroup.php
+++ b/findgroup.php
@@ -15,13 +15,13 @@ function badgewidgethack_convert_email_to_openbadges_id($email) {
 	);
 
 	$context  = stream_context_create($opts);
-	$emailjson = file_get_contents('http://beta.openbadges.org/displayer/convert/email', false, $context);
+	$emailjson = file_get_contents('https://backpack.openbadges.org/displayer/convert/email', false, $context);
 	$emaildata = json_decode($emailjson);
 	return $emaildata->userId;
 }
 
 function badgewidget_return_groups_given_badge_id($userid) {
-	$url = "http://beta.openbadges.org/displayer/" . $userid . "/groups.json";
+	$url = "https://backpack.openbadges.org/displayer/" . $userid . "/groups.json";
 	$groupjson = file_get_contents($url);
 	$groupdata = json_decode($groupjson,true);
 	return $groupdata;


### PR DESCRIPTION
The "beta.openbadges.org" domain stopped accepting CORS requests, so BadgeWidgetHack isn't working at the moment. The 1.0 release backpack at backpack.openbadges.org is still configured correctly, so this PR changes request urls to use the new domain.